### PR TITLE
Fixed typo in quick start in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Natural numbers as the initial algebra for the `Option` endofunctor.
     val succ = (n: Nat) => In[Option](Some(n))
 
     val two   = succ(succ(zero))
-    val three = succ(three)
+    val three = succ(two)
 
 Conversion to `Int` as a catamorphism.
 


### PR DESCRIPTION
Current readme has typo which causes error during attempt to run. Sample error mesage like: 
error: recursive value three needs type
